### PR TITLE
feat: add multi-repo support

### DIFF
--- a/src/references/changes.rs
+++ b/src/references/changes.rs
@@ -296,7 +296,8 @@ mod test {
         let branch_name = String::from("main");
 
         let changes =
-            ReferenceChanges::new(ProjectLine::with(branch_name, None), &wiki, &ref_map).unwrap();
+            ReferenceChanges::new(ProjectLine::new(None, branch_name, None), &wiki, &ref_map)
+                .unwrap();
 
         assert_eq!(
             changes.new_cnt_map.len(),
@@ -341,7 +342,7 @@ mod test {
         let branch_link = String::from("https://github.com/mhatzl/mantra/tree/main");
 
         let changes = ReferenceChanges::new(
-            ProjectLine::with(branch_name, Some(branch_link.clone())),
+            ProjectLine::new(None, branch_name, Some(branch_link.clone())),
             &wiki,
             &ref_map,
         )
@@ -412,7 +413,7 @@ mod test {
         let branch_link = String::from("https://github.com/mhatzl/mantra/tree/main");
 
         let changes = ReferenceChanges::new(
-            ProjectLine::with(branch_name, Some(branch_link.clone())),
+            ProjectLine::new(None, branch_name, Some(branch_link.clone())),
             &wiki,
             &ref_map,
         );
@@ -450,7 +451,7 @@ mod test {
         let branch_link = String::from("https://github.com/mhatzl/mantra/tree/main");
 
         let changes = ReferenceChanges::new(
-            ProjectLine::with(branch_name, Some(branch_link.clone())),
+            ProjectLine::new(None, branch_name, Some(branch_link.clone())),
             &wiki,
             &ref_map,
         )

--- a/src/references/mod.rs
+++ b/src/references/mod.rs
@@ -177,8 +177,12 @@ pub enum ReferencesError {
     },
 
     // [req:wiki.ref_list.deprecated]
-    #[error("Deprecated requirement with ID '{}' or a sub-requirement of it is referenced at least once in branch '{}'.", .req_id, .branch_name)]
-    DeprecatedReqReferenced { req_id: String, branch_name: String },
+    #[error("Deprecated requirement with ID '{}' or a sub-requirement of it is referenced at least once {}in branch '{}'.", .req_id, .repo_name.as_ref().map(|r| format!("in repo {} ", r)).unwrap_or(String::new()), .branch_name)]
+    DeprecatedReqReferenced {
+        req_id: String,
+        repo_name: Option<String>,
+        branch_name: String,
+    },
 }
 
 #[cfg(test)]

--- a/src/release/mod.rs
+++ b/src/release/mod.rs
@@ -121,7 +121,7 @@ fn release_list<'a>(
             if let Some(entry) = req
                 .ref_list
                 .iter()
-                .find(|entry| entry.branch_name.as_str() == branch)
+                .find(|entry| entry.proj_line.branch_name.as_str() == branch)
             {
                 if !entry.is_deprecated
                     && (entry.is_manual || (!checklist && entry.ref_cnt != RefCntKind::Untraced))

--- a/src/status/branch.rs
+++ b/src/status/branch.rs
@@ -26,7 +26,7 @@ pub fn status_branch(wiki: &Wiki, param: &StatusParameter) -> String {
         match req
             .ref_list
             .iter()
-            .find(|entry| entry.branch_name.as_ref() == &param.branch)
+            .find(|entry| entry.proj_line.branch_name.as_ref() == &param.branch)
         {
             Some(entry) => {
                 if entry.is_deprecated {

--- a/src/status/cmp.rs
+++ b/src/status/cmp.rs
@@ -71,7 +71,7 @@ pub fn status_cmp(wiki: &Wiki, branch_a: &str, branch_b: &str) -> String {
 fn req_phase(ref_list: &[RefListEntry], branch: &str) -> String {
     let phase = match ref_list
         .iter()
-        .find(|entry| entry.branch_name.as_str() == branch)
+        .find(|entry| entry.proj_line.branch_name.as_str() == branch)
     {
         Some(entry) => {
             if entry.is_deprecated {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -9,7 +9,7 @@ use clap::Args;
 use crate::{
     globals::GlobalParameter,
     references::{changes::ReferenceChanges, ReferencesError, ReferencesMap},
-    wiki::{Wiki, WikiError},
+    wiki::{ref_list::ProjectLine, Wiki, WikiError},
 };
 
 /// Parameters for the `sync` command.
@@ -33,6 +33,12 @@ pub struct SyncParameter {
     /// [req:wiki.ref_list.branch_link]
     #[arg(long)]
     pub branch_link: Option<String>,
+
+    /// Optional repository name in case multiple repositories point to the same wiki.
+    ///
+    /// [req:wiki.ref_list.repo]
+    #[arg(long, alias = "repo")]
+    pub repo_name: Option<String>,
 }
 
 /// Synchronizes requirement references between requirements in a wiki, and references to them in a project.
@@ -43,11 +49,11 @@ pub fn sync(params: &SyncParameter) -> Result<(), SyncError> {
     let ref_map = ReferencesMap::try_from((&wiki, &params.global.proj_folder))?;
 
     let changes = ReferenceChanges::new(
-        params.branch_name.clone().into(),
-        params
-            .branch_link
-            .as_ref()
-            .map(|link| std::sync::Arc::new(link.clone())),
+        ProjectLine::new(
+            params.repo_name.clone(),
+            params.branch_name.clone(),
+            params.branch_link.clone(),
+        ),
         &wiki,
         &ref_map,
     )?;

--- a/src/wiki/mod.rs
+++ b/src/wiki/mod.rs
@@ -149,12 +149,21 @@ impl Wiki {
         self.req_map.get(req_id).is_none() && self.sub_map.get(req_id).is_some()
     }
 
-    pub fn req_ref_entry(&self, req_id: &ReqId, branch_name: &str) -> Option<&RefListEntry> {
+    /// Get the *references* list entry for the given requirement ID,
+    /// and repository and branch name.
+    ///
+    /// [req:wiki.ref_list.repo]
+    pub fn req_ref_entry(
+        &self,
+        req_id: &ReqId,
+        repo: Option<&str>,
+        branch_name: &str,
+    ) -> Option<&RefListEntry> {
         match self.req(req_id) {
-            Some(wiki_req) => wiki_req
-                .ref_list
-                .iter()
-                .find(|entry| entry.branch_name.as_ref() == branch_name),
+            Some(wiki_req) => wiki_req.ref_list.iter().find(|entry| {
+                entry.proj_line.branch_name.as_ref() == branch_name
+                    && entry.proj_line.repo_name.as_ref().map(|r| r.as_str()) == repo
+            }),
             None => None,
         }
     }

--- a/src/wiki/ref_list.rs
+++ b/src/wiki/ref_list.rs
@@ -47,14 +47,6 @@ impl ProjectLine {
             repo_name: repo_name.map(|s| s.into()),
         }
     }
-
-    pub fn with(branch_name: String, branch_link: Option<String>) -> Self {
-        ProjectLine {
-            branch_name: branch_name.into(),
-            branch_link: branch_link.map(|s| s.into()),
-            repo_name: None,
-        }
-    }
 }
 
 /// Represents one entry inside the *references* list.


### PR DESCRIPTION
# List of issues that this PR closes

closes #20 

# Definition of Done ([req:qa.DoD])

**Please consider the following requirements:**

- [x] Add/Update requirement references (see: [req:qa.tracing])

**Note:** You may ignore requirements that are not relevant to your PR.

# Relevant decisions you made in this PR

It was decided to use `in repo` instead of `in project`, because `repo` more clearly states that multiple repositories may be used.

**Example:**

```
**References:**

- in repo mantra in branch main: 2
- in repo mantra-wiki in branch main: 1
```