### PR TITLE
feat: add ignore file filter for referencing

### DIFF
--- a/.mantraignore
+++ b/.mantraignore
@@ -1,0 +1,4 @@
+Cargo.lock
+LICENSE
+CHANGELOG.md
+.*ignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "bstr"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +194,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -191,6 +220,23 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "is-terminal"
@@ -220,6 +266,12 @@ name = "linux-raw-sys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "logid"
@@ -258,10 +310,10 @@ name = "mantra"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "ignore",
  "logid",
  "regex",
  "thiserror",
- "walkdir",
 ]
 
 [[package]]
@@ -382,6 +434,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +488,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ logid = "0.12.2"
 thiserror = "1.0.47"
 clap = { version = "4.4.1", features = ["derive"] }
 regex = "1.9.3"
-walkdir = "2.3.3"
+ignore = "0.4.20"

--- a/src/references/mod.rs
+++ b/src/references/mod.rs
@@ -59,8 +59,6 @@ impl TryFrom<(&Wiki, &PathBuf)> for ReferencesMap {
                     Err(_) => continue,
                 };
 
-                println!("{:?}", &dir_entry);
-
                 if dir_entry.file_type().expect("No file type found for given project folder. Note: stdin is not supported.").is_file() {
                     let res_content = std::fs::read_to_string(dir_entry.path()).map_err(|_| {
                         logid::pipe!(ReferencesError::CouldNotAccessFile(


### PR DESCRIPTION
# List of issues that this PR closes

closes #19 

# Definition of Done ([req:qa.DoD])

**Please consider the following requirements:**

- [x] Add/Update requirement references (see: [req:qa.tracing])

**Note:** You may ignore requirements that are not relevant to your PR.

# Relevant decisions you made in this PR

Switched from crate `walkdir` to `ignore`, because it provides filtering using ignore files,
and provides a built-in iterator over all path entries.

`.mantraignore` is recognized, but takes precedence over others, because this is the behaviour of the `ignore` crate.
However, negating ignores made in `.gitignore` won't help if mantra commands are only run in workflows, because due to `.gitignore`, files and folders won't be pushed to the remote if ignored.
