### PR TITLE
Set CI test job to use MSRV version and llvm-tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.90.0
-        with:
-          components: llvm-tools
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@grcov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.90.0
+        with:
+          components: llvm-tools
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@grcov

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.90"
-components = ["llvm-tools"]
+components = ["clippy", "llvm-tools", "rustfmt"]


### PR DESCRIPTION
Ensures CI uses MSRV for testing and that llvm-tools is installed