### PR TITLE
bump mantra version to v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "mantra"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/mantra/Cargo.toml
+++ b/mantra/Cargo.toml
@@ -3,10 +3,10 @@ name = "mantra"
 description = "`mantra` offers a lightweight approach for requirement tracing and coverage."
 rust-version = "1.90"
 readme.workspace = true
-version.workspace = true
 edition.workspace = true
 repository.workspace = true
 license.workspace = true
+version = "0.8.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
Fix only part of the mantra crate, so all others stay at v0.8.0
