### PR TITLE
Make mantra-macros no_std compatible

### DIFF
--- a/langs/rust/mantra-macros/src/lib.rs
+++ b/langs/rust/mantra-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 pub use mantra_procm::*;
 
 #[macro_export]


### PR DESCRIPTION
Missed to set `no_std`. Crate would have already been compatible.
Allows to use `mantra-macros` in `no_std` crates.
