### PR TITLE
Adds feature to set defmt logs for mantra traces on functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,7 @@ name = "mantra-macros"
 version = "0.8.0"
 dependencies = [
  "defmt",
+ "log",
  "mantra-procm",
  "regex",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,12 +1338,18 @@ dependencies = [
 name = "mantra-macros"
 version = "0.8.0"
 dependencies = [
+ "defmt",
  "mantra-procm",
+ "regex",
 ]
 
 [[package]]
 name = "mantra-procm"
 version = "0.8.0"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "mantra-schema"

--- a/langs/rust/mantra-macros/Cargo.toml
+++ b/langs/rust/mantra-macros/Cargo.toml
@@ -9,8 +9,11 @@ license.workspace = true
 [dependencies]
 mantra-procm = { path = "../mantra-procm", version = "0.8.0" }
 regex = { workspace = true, optional = true }
+log = { workspace = true, optional = true }
 defmt = { version = "1", optional = true }
 
 [features]
-defmt = ["dep:defmt", "mantra-procm/defmt"]
+coverage = []
+log = ["coverage", "dep:log"]
+defmt = ["coverage", "dep:defmt", "mantra-procm/defmt"]
 extract = ["dep:regex"]

--- a/langs/rust/mantra-macros/Cargo.toml
+++ b/langs/rust/mantra-macros/Cargo.toml
@@ -8,7 +8,9 @@ license.workspace = true
 
 [dependencies]
 mantra-procm = { path = "../mantra-procm", version = "0.8.0" }
-# defmt = { version = "0.3.6", optional = true }
+regex = { workspace = true, optional = true }
+defmt = { version = "1", optional = true }
 
 [features]
-# defmt = ["dep:defmt"]
+defmt = ["dep:defmt", "mantra-procm/defmt"]
+extract = ["dep:regex"]

--- a/langs/rust/mantra-macros/src/coverage.rs
+++ b/langs/rust/mantra-macros/src/coverage.rs
@@ -39,6 +39,9 @@ impl LineCoverage {
     pub fn log(&self) {
         #[cfg(feature = "defmt")]
         defmt::println!("{}", self);
+
+        #[cfg(feature = "log")]
+        log::info!("{}", self);
     }
 
     /// Returns `true` if the given string starts like a mantra coverage log message.

--- a/langs/rust/mantra-macros/src/coverage.rs
+++ b/langs/rust/mantra-macros/src/coverage.rs
@@ -114,6 +114,28 @@ pub enum ExtractError {
     BadFile,
 }
 
+#[cfg(feature = "extract")]
+impl core::fmt::Display for ExtractError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExtractError::Unmatched => {
+                write!(f, "Given content did not match a mantra coverage statement")
+            }
+            ExtractError::BadLine => write!(
+                f,
+                "The line entry for the mantra coverage statement is invalid"
+            ),
+            ExtractError::BadFile => write!(
+                f,
+                "The file entry for the mantra coverage statement is invalid"
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "extract")]
+impl core::error::Error for ExtractError {}
+
 #[cfg(all(test, feature = "extract"))]
 mod tests {
     use core::{assert_eq, str::FromStr};

--- a/langs/rust/mantra-macros/src/coverage.rs
+++ b/langs/rust/mantra-macros/src/coverage.rs
@@ -1,0 +1,169 @@
+/// The line in a file that was covered by a mantra macro.
+#[cfg_attr(feature = "extract", derive(Debug, Clone, PartialEq, Eq))]
+pub struct LineCoverage {
+    line: u32,
+    #[cfg(not(feature = "extract"))]
+    file: &'static str,
+    #[cfg(feature = "extract")]
+    file: String,
+}
+
+impl LineCoverage {
+    /// Create a new line coverage preferably using `line!()` and `file!()`.
+    #[cfg(not(feature = "extract"))]
+    pub fn new(line: u32, file: &'static str) -> Self {
+        Self { line, file }
+    }
+
+    /// Create a new line coverage preferably using `line!()` and `file!()`.
+    #[cfg(feature = "extract")]
+    pub fn new(line: u32, file: impl Into<String>) -> Self {
+        Self {
+            line,
+            file: file.into(),
+        }
+    }
+
+    pub fn line(&self) -> u32 {
+        self.line
+    }
+
+    pub fn file(&self) -> &str {
+        #[cfg(not(feature = "extract"))]
+        return self.file;
+
+        #[cfg(feature = "extract")]
+        &self.file
+    }
+
+    pub fn log(&self) {
+        #[cfg(feature = "defmt")]
+        defmt::println!("{}", self);
+    }
+
+    /// Returns `true` if the given string starts like a mantra coverage log message.
+    ///
+    /// `mantra coverage at line='`
+    pub fn potential_log(msg: &str) -> bool {
+        msg.starts_with("mantra coverage at line='")
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for LineCoverage {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{}", defmt::Display2Format(self));
+    }
+}
+
+impl core::fmt::Display for LineCoverage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::write!(
+            f,
+            "mantra coverage at line='{}' in file: {}",
+            self.line,
+            self.file()
+        )
+    }
+}
+
+#[cfg(feature = "extract")]
+static MANTRA_LINE_COV_REGEX: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(r"mantra coverage at line='(?<line>\d+)' in file: (?<file>.+)").unwrap()
+});
+
+#[cfg(feature = "extract")]
+const FILE_MATCH_NAME: &str = "file";
+#[cfg(feature = "extract")]
+const LINE_MATCH_NAME: &str = "line";
+
+#[cfg(feature = "extract")]
+impl core::str::FromStr for LineCoverage {
+    type Err = ExtractError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match MANTRA_LINE_COV_REGEX.captures(s) {
+            Some(captures) => {
+                let file_match = captures
+                    .name(FILE_MATCH_NAME)
+                    .ok_or(ExtractError::BadFile)?;
+                let file = file_match.as_str();
+                let line_match = captures
+                    .name(LINE_MATCH_NAME)
+                    .ok_or(ExtractError::BadLine)?;
+                let line: u32 = line_match
+                    .as_str()
+                    .parse()
+                    .map_err(|_| ExtractError::BadLine)?;
+
+                Ok(LineCoverage::new(line, file))
+            }
+            None => Err(ExtractError::Unmatched),
+        }
+    }
+}
+
+#[cfg(feature = "extract")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtractError {
+    Unmatched,
+    BadLine,
+    BadFile,
+}
+
+#[cfg(all(test, feature = "extract"))]
+mod tests {
+    use core::{assert_eq, str::FromStr};
+
+    use crate::coverage::{ExtractError, LineCoverage};
+
+    #[test]
+    fn extract_valid_coverage() {
+        let coverage = LineCoverage::new(1, "some-file");
+
+        let extracted = LineCoverage::from_str(&coverage.to_string()).unwrap();
+        assert_eq!(
+            coverage, extracted,
+            "Extracted (right) from orig (left) differ"
+        );
+    }
+
+    #[test]
+    fn extract_valid_coverage_longer_filepath() {
+        let coverage = LineCoverage::new(1, "path/path/path/path/some-longer-nested-filepath");
+
+        let extracted = LineCoverage::from_str(&coverage.to_string()).unwrap();
+        assert_eq!(
+            coverage, extracted,
+            "Extracted (right) from orig (left) differ"
+        );
+    }
+
+    #[test]
+    fn unmatched_msg() {
+        let msg = "mantra coverage at line='1";
+        let err = LineCoverage::from_str(msg).unwrap_err();
+
+        assert!(
+            LineCoverage::potential_log(msg),
+            "Message does not start like a mantra coverage log"
+        );
+        assert_eq!(
+            err,
+            ExtractError::Unmatched,
+            "Message is not a valid mantra coverage log"
+        )
+    }
+
+    #[test]
+    fn bad_line() {
+        let msg = "mantra coverage at line='123456789000' in file: some-file";
+        let err = LineCoverage::from_str(msg).unwrap_err();
+
+        assert!(
+            LineCoverage::potential_log(msg),
+            "Message does not start like a mantra coverage log"
+        );
+        assert_eq!(err, ExtractError::BadLine, "Line number exceeds u32")
+    }
+}

--- a/langs/rust/mantra-macros/src/lib.rs
+++ b/langs/rust/mantra-macros/src/lib.rs
@@ -4,7 +4,7 @@ pub use mantra_procm::*;
 
 pub mod coverage;
 
-#[cfg(feature = "defmt")]
+#[cfg(feature = "coverage")]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _line_coverage {
@@ -13,11 +13,22 @@ macro_rules! _line_coverage {
     };
 }
 
+#[cfg(not(feature = "coverage"))]
 #[macro_export]
 macro_rules! satisfy_req {
     ($($id:literal),+ => $code:expr) => {
         {
-            #[cfg(feature = "defmt")]
+            $(const _: &str = $id;)+
+            $code
+        }
+    };
+}
+
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! satisfy_req {
+    ($($id:literal),+ => $code:expr) => {
+        {
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -26,11 +37,22 @@ macro_rules! satisfy_req {
     };
 }
 
+#[cfg(not(feature = "coverage"))]
 #[macro_export]
 macro_rules! impl_req {
     ($($id:literal),+ => $code:expr) => {
         {
-            #[cfg(feature = "defmt")]
+            $(const _: &str = $id;)+
+            $code
+        }
+    };
+}
+
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! impl_req {
+    ($($id:literal),+ => $code:expr) => {
+        {
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -39,11 +61,22 @@ macro_rules! impl_req {
     };
 }
 
+#[cfg(not(feature = "coverage"))]
 #[macro_export]
 macro_rules! verify_req {
     ($($id:literal),+ => $code:expr) => {
         {
-            #[cfg(feature = "defmt")]
+            $(const _: &str = $id;)+
+            $code
+        }
+    };
+}
+
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! verify_req {
+    ($($id:literal),+ => $code:expr) => {
+        {
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -52,11 +85,22 @@ macro_rules! verify_req {
     };
 }
 
+#[cfg(not(feature = "coverage"))]
 #[macro_export]
 macro_rules! clarify_req {
     ($($id:literal),+ => $code:expr) => {
         {
-            #[cfg(feature = "defmt")]
+            $(const _: &str = $id;)+
+            $code
+        }
+    };
+}
+
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! clarify_req {
+    ($($id:literal),+ => $code:expr) => {
+        {
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -65,11 +109,22 @@ macro_rules! clarify_req {
     };
 }
 
+#[cfg(not(feature = "coverage"))]
 #[macro_export]
 macro_rules! link_req {
     ($($id:literal),+ => $code:expr) => {
         {
-            #[cfg(feature = "defmt")]
+            $(const _: &str = $id;)+
+            $code
+        }
+    };
+}
+
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! link_req {
+    ($($id:literal),+ => $code:expr) => {
+        {
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -78,11 +133,36 @@ macro_rules! link_req {
     };
 }
 
+#[cfg(not(feature = "coverage"))]
 #[macro_export]
 macro_rules! assert_req {
     ($($id:literal),+ => $code:expr) => {
         {
-            #[cfg(feature = "defmt")]
+            $(const _: &str = $id;)+
+            core::assert!($code)
+        }
+    };
+
+    ($($id:literal),+ => $code:expr, $msg:literal) => {
+        {
+            $(const _: &str = $id;)+
+            core::assert!($code, $msg)
+        }
+    };
+
+    ($($id:literal),+ => $code:expr, $msg:literal, $($param:expr),+$(,)?) => {
+        {
+            $(const _: &str = $id;)+
+            core::assert!($code, $msg, $($param),+)
+        }
+    };
+}
+
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! assert_req {
+    ($($id:literal),+ => $code:expr) => {
+        {
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -92,7 +172,6 @@ macro_rules! assert_req {
 
     ($($id:literal),+ => $code:expr, $msg:literal) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -102,7 +181,6 @@ macro_rules! assert_req {
 
     ($($id:literal),+ => $code:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -111,11 +189,36 @@ macro_rules! assert_req {
     };
 }
 
+#[cfg(not(feature = "coverage"))]
 #[macro_export]
 macro_rules! debug_assert_req {
     ($($id:literal),+ => $code:expr) => {
         {
-            #[cfg(feature = "defmt")]
+            $(const _: &str = $id;)+
+            core::debug_assert!($code)
+        }
+    };
+
+    ($($id:literal),+ => $code:expr, $msg:literal) => {
+        {
+            $(const _: &str = $id;)+
+            core::debug_assert!($code, $msg)
+        }
+    };
+
+    ($($id:literal),+ => $code:expr, $msg:literal, $($param:expr),+$(,)?) => {
+        {
+            $(const _: &str = $id;)+
+            core::debug_assert!($code, $msg, $($param),+)
+        }
+    };
+}
+
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! debug_assert_req {
+    ($($id:literal),+ => $code:expr) => {
+        {
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -125,7 +228,6 @@ macro_rules! debug_assert_req {
 
     ($($id:literal),+ => $code:expr, $msg:literal) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -135,7 +237,6 @@ macro_rules! debug_assert_req {
 
     ($($id:literal),+ => $code:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -144,11 +245,36 @@ macro_rules! debug_assert_req {
     };
 }
 
+#[cfg(not(feature = "coverage"))]
 #[macro_export]
 macro_rules! assert_eq_req {
     ($($id:literal),+ => $left:expr, $right:expr) => {
         {
-            #[cfg(feature = "defmt")]
+            $(const _: &str = $id;)+
+            core::assert_eq!($left, $right)
+        }
+    };
+
+    ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
+        {
+            $(const _: &str = $id;)+
+            core::assert_eq!($left, $right, $msg)
+        }
+    };
+
+    ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
+        {
+            $(const _: &str = $id;)+
+            core::assert_eq!($left, $right, $msg, $($param),+)
+        }
+    };
+}
+
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! assert_eq_req {
+    ($($id:literal),+ => $left:expr, $right:expr) => {
+        {
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -158,7 +284,6 @@ macro_rules! assert_eq_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -168,7 +293,6 @@ macro_rules! assert_eq_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -177,11 +301,36 @@ macro_rules! assert_eq_req {
     };
 }
 
+#[cfg(not(feature = "coverage"))]
 #[macro_export]
 macro_rules! debug_assert_eq_req {
     ($($id:literal),+ => $left:expr, $right:expr) => {
         {
-            #[cfg(feature = "defmt")]
+            $(const _: &str = $id;)+
+            core::debug_assert_eq!($left, $right)
+        }
+    };
+
+    ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
+        {
+            $(const _: &str = $id;)+
+            core::debug_assert_eq!($left, $right, $msg)
+        }
+    };
+
+    ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
+        {
+            $(const _: &str = $id;)+
+            core::debug_assert_eq!($left, $right, $msg, $($param),+)
+        }
+    };
+}
+
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! debug_assert_eq_req {
+    ($($id:literal),+ => $left:expr, $right:expr) => {
+        {
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -191,7 +340,6 @@ macro_rules! debug_assert_eq_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -201,7 +349,6 @@ macro_rules! debug_assert_eq_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -210,11 +357,36 @@ macro_rules! debug_assert_eq_req {
     };
 }
 
+#[cfg(not(feature = "coverage"))]
 #[macro_export]
 macro_rules! assert_ne_req {
     ($($id:literal),+ => $left:expr, $right:expr) => {
         {
-            #[cfg(feature = "defmt")]
+            $(const _: &str = $id;)+
+            core::assert_ne!($left, $right)
+        }
+    };
+
+    ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
+        {
+            $(const _: &str = $id;)+
+            core::assert_ne!($left, $right, $msg)
+        }
+    };
+
+    ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
+        {
+            $(const _: &str = $id;)+
+            core::assert_ne!($left, $right, $msg, $($param),+)
+        }
+    };
+}
+
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! assert_ne_req {
+    ($($id:literal),+ => $left:expr, $right:expr) => {
+        {
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -224,7 +396,6 @@ macro_rules! assert_ne_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -234,7 +405,6 @@ macro_rules! assert_ne_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -243,11 +413,36 @@ macro_rules! assert_ne_req {
     };
 }
 
+#[cfg(not(feature = "coverage"))]
 #[macro_export]
 macro_rules! debug_assert_ne_req {
     ($($id:literal),+ => $left:expr, $right:expr) => {
         {
-            #[cfg(feature = "defmt")]
+            $(const _: &str = $id;)+
+            core::debug_assert_ne!($left, $right)
+        }
+    };
+
+    ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
+        {
+            $(const _: &str = $id;)+
+            core::debug_assert_ne!($left, $right, $msg)
+        }
+    };
+
+    ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
+        {
+            $(const _: &str = $id;)+
+            core::debug_assert_ne!($left, $right, $msg, $($param),+)
+        }
+    };
+}
+
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! debug_assert_ne_req {
+    ($($id:literal),+ => $left:expr, $right:expr) => {
+        {
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -257,7 +452,6 @@ macro_rules! debug_assert_ne_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+
@@ -267,7 +461,6 @@ macro_rules! debug_assert_ne_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
-            #[cfg(feature = "defmt")]
             $crate::_line_coverage!();
 
             $(const _: &str = $id;)+

--- a/langs/rust/mantra-macros/src/lib.rs
+++ b/langs/rust/mantra-macros/src/lib.rs
@@ -1,11 +1,25 @@
-#![no_std]
+#![cfg_attr(not(feature = "extract"), no_std)]
 
 pub use mantra_procm::*;
+
+pub mod coverage;
+
+#[cfg(feature = "defmt")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _line_coverage {
+    () => {
+        $crate::coverage::LineCoverage::new(line!(), file!()).log();
+    };
+}
 
 #[macro_export]
 macro_rules! satisfy_req {
     ($($id:literal),+ => $code:expr) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             $code
         }
@@ -16,6 +30,9 @@ macro_rules! satisfy_req {
 macro_rules! impl_req {
     ($($id:literal),+ => $code:expr) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             $code
         }
@@ -26,6 +43,9 @@ macro_rules! impl_req {
 macro_rules! verify_req {
     ($($id:literal),+ => $code:expr) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             $code
         }
@@ -36,6 +56,9 @@ macro_rules! verify_req {
 macro_rules! clarify_req {
     ($($id:literal),+ => $code:expr) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             $code
         }
@@ -46,6 +69,9 @@ macro_rules! clarify_req {
 macro_rules! link_req {
     ($($id:literal),+ => $code:expr) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             $code
         }
@@ -56,6 +82,9 @@ macro_rules! link_req {
 macro_rules! assert_req {
     ($($id:literal),+ => $code:expr) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::assert!($code)
         }
@@ -63,6 +92,9 @@ macro_rules! assert_req {
 
     ($($id:literal),+ => $code:expr, $msg:literal) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::assert!($code, $msg)
         }
@@ -70,6 +102,9 @@ macro_rules! assert_req {
 
     ($($id:literal),+ => $code:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::assert!($code, $msg, $($param),+)
         }
@@ -80,6 +115,9 @@ macro_rules! assert_req {
 macro_rules! debug_assert_req {
     ($($id:literal),+ => $code:expr) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::debug_assert!($code)
         }
@@ -87,6 +125,9 @@ macro_rules! debug_assert_req {
 
     ($($id:literal),+ => $code:expr, $msg:literal) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::debug_assert!($code, $msg)
         }
@@ -94,6 +135,9 @@ macro_rules! debug_assert_req {
 
     ($($id:literal),+ => $code:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::debug_assert!($code, $msg, $($param),+)
         }
@@ -104,6 +148,9 @@ macro_rules! debug_assert_req {
 macro_rules! assert_eq_req {
     ($($id:literal),+ => $left:expr, $right:expr) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::assert_eq!($left, $right)
         }
@@ -111,6 +158,9 @@ macro_rules! assert_eq_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::assert_eq!($left, $right, $msg)
         }
@@ -118,6 +168,9 @@ macro_rules! assert_eq_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::assert_eq!($left, $right, $msg, $($param),+)
         }
@@ -128,6 +181,9 @@ macro_rules! assert_eq_req {
 macro_rules! debug_assert_eq_req {
     ($($id:literal),+ => $left:expr, $right:expr) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::debug_assert_eq!($left, $right)
         }
@@ -135,6 +191,9 @@ macro_rules! debug_assert_eq_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::debug_assert_eq!($left, $right, $msg)
         }
@@ -142,6 +201,9 @@ macro_rules! debug_assert_eq_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::debug_assert_eq!($left, $right, $msg, $($param),+)
         }
@@ -152,6 +214,9 @@ macro_rules! debug_assert_eq_req {
 macro_rules! assert_ne_req {
     ($($id:literal),+ => $left:expr, $right:expr) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::assert_ne!($left, $right)
         }
@@ -159,6 +224,9 @@ macro_rules! assert_ne_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::assert_ne!($left, $right, $msg)
         }
@@ -166,6 +234,9 @@ macro_rules! assert_ne_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::assert_ne!($left, $right, $msg, $($param),+)
         }
@@ -176,6 +247,9 @@ macro_rules! assert_ne_req {
 macro_rules! debug_assert_ne_req {
     ($($id:literal),+ => $left:expr, $right:expr) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::debug_assert_ne!($left, $right)
         }
@@ -183,6 +257,9 @@ macro_rules! debug_assert_ne_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::debug_assert_ne!($left, $right, $msg)
         }
@@ -190,6 +267,9 @@ macro_rules! debug_assert_ne_req {
 
     ($($id:literal),+ => $left:expr, $right:expr, $msg:literal, $($param:expr),+$(,)?) => {
         {
+            #[cfg(feature = "defmt")]
+            $crate::_line_coverage!();
+
             $(const _: &str = $id;)+
             core::debug_assert_ne!($left, $right, $msg, $($param),+)
         }

--- a/langs/rust/mantra-macros/src/lib.rs
+++ b/langs/rust/mantra-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 pub use mantra_procm::*;
 
 #[macro_export]

--- a/langs/rust/mantra-procm/Cargo.toml
+++ b/langs/rust/mantra-procm/Cargo.toml
@@ -7,7 +7,11 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-# quote = "1.0"
+syn = { version = "2.0", features = ["full"], optional = true }
+quote = { version = "1.0", optional = true }
+
+[features]
+defmt = ["dep:syn", "dep:quote"]
 
 [lib]
 proc-macro = true

--- a/langs/rust/mantra-procm/src/lib.rs
+++ b/langs/rust/mantra-procm/src/lib.rs
@@ -2,30 +2,73 @@ use proc_macro::TokenStream;
 
 #[proc_macro_attribute]
 pub fn req(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(feature = "defmt")]
+    return defmt_wrap(item);
+
+    #[cfg(not(feature = "defmt"))]
     item
 }
 
 #[proc_macro_attribute]
 pub fn req_satisfied(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(feature = "defmt")]
+    return defmt_wrap(item);
+
+    #[cfg(not(feature = "defmt"))]
     item
 }
 
 #[proc_macro_attribute]
 pub fn req_verified(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(feature = "defmt")]
+    return defmt_wrap(item);
+
+    #[cfg(not(feature = "defmt"))]
     item
 }
 
 #[proc_macro_attribute]
 pub fn req_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(feature = "defmt")]
+    return defmt_wrap(item);
+
+    #[cfg(not(feature = "defmt"))]
     item
 }
 
 #[proc_macro_attribute]
 pub fn req_note(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(feature = "defmt")]
+    return defmt_wrap(item);
+
+    #[cfg(not(feature = "defmt"))]
     item
 }
 
 #[proc_macro_attribute]
 pub fn req_link(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(feature = "defmt")]
+    return defmt_wrap(item);
+
+    #[cfg(not(feature = "defmt"))]
     item
+}
+
+#[cfg(feature = "defmt")]
+/// Create a defmnt log to use as line coverage marker for embedded testing
+fn defmt_wrap(item: TokenStream) -> TokenStream {
+    if let Ok(parsed_item) = syn::parse::<syn::Item>(item.clone()) {
+        match parsed_item {
+            syn::Item::Fn(mut fn_item) => {
+                let macro_stmt: syn::Stmt = syn::parse_quote!(mantra_macros::_line_coverage!(););
+
+                fn_item.block.stmts.insert(0, macro_stmt);
+
+                quote::quote!(#fn_item).into()
+            }
+            _ => item,
+        }
+    } else {
+        item
+    }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.90"
-components = ["clippy", "llvm-tools", "rustfmt"]
+components = ["clippy", "llvm-tools", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
This adds the `defmt` feature to `mantra-macros` and `mantra-procm` to set a defmt log for traces set on functions.
For embedded targets, the host side may then extract those logs to retrieve mantra coverage information during testing.

The `extract` feature of `mantra-macros` adds functionality to extract the coverage information from log messages. Having extract functionality in this crate keeps it close to the code defining the message format and setting the logs.
