### PR TITLE
Set coverage log in proc macro crate not just for defmt

### DIFF
--- a/langs/rust/mantra-macros/Cargo.toml
+++ b/langs/rust/mantra-macros/Cargo.toml
@@ -13,7 +13,7 @@ log = { workspace = true, optional = true }
 defmt = { version = "1", optional = true }
 
 [features]
-coverage = []
+coverage = ["mantra-procm/coverage"]
 log = ["coverage", "dep:log"]
-defmt = ["coverage", "dep:defmt", "mantra-procm/defmt"]
+defmt = ["coverage", "dep:defmt"]
 extract = ["dep:regex"]

--- a/langs/rust/mantra-macros/src/lib.rs
+++ b/langs/rust/mantra-macros/src/lib.rs
@@ -4,6 +4,9 @@ pub use mantra_procm::*;
 
 pub mod coverage;
 
+#[cfg(all(feature = "log", feature = "defmt"))]
+compile_error!("Features 'log' and 'defmt' must not both be activated at the same time");
+
 #[cfg(feature = "coverage")]
 #[doc(hidden)]
 #[macro_export]

--- a/langs/rust/mantra-procm/Cargo.toml
+++ b/langs/rust/mantra-procm/Cargo.toml
@@ -11,7 +11,7 @@ syn = { version = "2.0", features = ["full"], optional = true }
 quote = { version = "1.0", optional = true }
 
 [features]
-defmt = ["dep:syn", "dep:quote"]
+coverage = ["dep:syn", "dep:quote"]
 
 [lib]
 proc-macro = true

--- a/langs/rust/mantra-procm/src/lib.rs
+++ b/langs/rust/mantra-procm/src/lib.rs
@@ -2,61 +2,61 @@ use proc_macro::TokenStream;
 
 #[proc_macro_attribute]
 pub fn req(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    #[cfg(feature = "defmt")]
-    return defmt_wrap(item);
+    #[cfg(feature = "coverage")]
+    return coverage_wrap(item);
 
-    #[cfg(not(feature = "defmt"))]
+    #[cfg(not(feature = "coverage"))]
     item
 }
 
 #[proc_macro_attribute]
 pub fn req_satisfied(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    #[cfg(feature = "defmt")]
-    return defmt_wrap(item);
+    #[cfg(feature = "coverage")]
+    return coverage_wrap(item);
 
-    #[cfg(not(feature = "defmt"))]
+    #[cfg(not(feature = "coverage"))]
     item
 }
 
 #[proc_macro_attribute]
 pub fn req_verified(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    #[cfg(feature = "defmt")]
-    return defmt_wrap(item);
+    #[cfg(feature = "coverage")]
+    return coverage_wrap(item);
 
-    #[cfg(not(feature = "defmt"))]
+    #[cfg(not(feature = "coverage"))]
     item
 }
 
 #[proc_macro_attribute]
 pub fn req_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    #[cfg(feature = "defmt")]
-    return defmt_wrap(item);
+    #[cfg(feature = "coverage")]
+    return coverage_wrap(item);
 
-    #[cfg(not(feature = "defmt"))]
+    #[cfg(not(feature = "coverage"))]
     item
 }
 
 #[proc_macro_attribute]
 pub fn req_note(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    #[cfg(feature = "defmt")]
-    return defmt_wrap(item);
+    #[cfg(feature = "coverage")]
+    return coverage_wrap(item);
 
-    #[cfg(not(feature = "defmt"))]
+    #[cfg(not(feature = "coverage"))]
     item
 }
 
 #[proc_macro_attribute]
 pub fn req_link(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    #[cfg(feature = "defmt")]
-    return defmt_wrap(item);
+    #[cfg(feature = "coverage")]
+    return coverage_wrap(item);
 
-    #[cfg(not(feature = "defmt"))]
+    #[cfg(not(feature = "coverage"))]
     item
 }
 
-#[cfg(feature = "defmt")]
+#[cfg(feature = "coverage")]
 /// Create a defmnt log to use as line coverage marker for embedded testing
-fn defmt_wrap(item: TokenStream) -> TokenStream {
+fn coverage_wrap(item: TokenStream) -> TokenStream {
     if let Ok(parsed_item) = syn::parse::<syn::Item>(item.clone()) {
         match parsed_item {
             syn::Item::Fn(mut fn_item) => {


### PR DESCRIPTION
The mantra-procm only set coverage logs for the "defmt" feature.
With this PR, the feature flag is changed to "coverage" to set the coverage log depending on the feature flags set in mantra-macros.