### PR TITLE
Detects nested fn-like mantra macros

### DIFF
--- a/langs/mantra-lang-tracing/src/collect/rust/mod.rs
+++ b/langs/mantra-lang-tracing/src/collect/rust/mod.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{io::Cursor, str::FromStr};
 
 use anyhow::{anyhow, bail};
 use mantra_schema::{
@@ -105,6 +105,9 @@ impl AnnotationCollector for RustCodeCollector {
                 let end = node.end_position().row.try_into().unwrap_or(-1) + start_line;
                 let node_hash = Some(FmtHash::new(node.utf8_text(content_bytes)?));
 
+                let inner_traces =
+                    nested_fn_like(&mut args_node.walk(), content_bytes, start_line)?;
+
                 traces.push(Trace {
                     ids,
                     line: traced_line,
@@ -119,6 +122,10 @@ impl AnnotationCollector for RustCodeCollector {
                     kind: trace_kind,
                     properties: None,
                 });
+
+                if !inner_traces.is_empty() {
+                    traces.extend(inner_traces);
+                }
             } else if node_kind.ends_with("_item")
                 || node_kind == "extern_crate_declaration"
                 || node_kind == "use_declaration"
@@ -133,6 +140,54 @@ impl AnnotationCollector for RustCodeCollector {
             coverage_excludes: vec![],
         })
     }
+}
+
+fn nested_fn_like(
+    cursor: &mut TreeCursor,
+    content_bytes: &[u8],
+    start_line: Line,
+) -> Result<Vec<Trace>, anyhow::Error> {
+    let mut traces = Vec::new();
+
+    loop {
+        let go_next_sibling_or_parent = !cursor.goto_first_child();
+        if go_next_sibling_or_parent && goto_next_sibling_or_parent(cursor).is_none() {
+            break;
+        }
+
+        let node = cursor.node();
+        let node_kind = node.kind();
+
+        if node_kind == "identifier"
+            && let Some(trace_kind) = get_fn_macro_trace_kind(&node, content_bytes)
+            && let Some(exclamation) = node.next_sibling()
+            && exclamation.kind() == "!"
+            && let Some(macro_body) = exclamation.next_sibling()
+            && macro_body.kind() == "token_tree"
+        {
+            let ids = get_req_ids(&macro_body, content_bytes, start_line, true)?;
+            let traced_line: Line = node.start_position().row.try_into().unwrap_or(-1) + start_line;
+            let end = macro_body.end_position().row.try_into().unwrap_or(-1) + start_line;
+            let node_hash = Some(FmtHash::new(node.utf8_text(content_bytes)?));
+
+            traces.push(Trace {
+                ids,
+                line: traced_line,
+                related_code: Some(TraceRelatedCodeVariant::CodeBlock(CodeBlock {
+                    kind: mantra_schema::annotations::CodeBlockKind::Other,
+                    content_hash: node_hash,
+                    span: LineSpan {
+                        start: traced_line,
+                        end,
+                    },
+                })),
+                kind: trace_kind,
+                properties: None,
+            });
+        }
+    }
+
+    Ok(traces)
 }
 
 fn parse_cfg_attr_for_traces(

--- a/langs/mantra-lang-tracing/src/collect/rust/mod.rs
+++ b/langs/mantra-lang-tracing/src/collect/rust/mod.rs
@@ -126,6 +126,13 @@ impl AnnotationCollector for RustCodeCollector {
                 if !inner_traces.is_empty() {
                     traces.extend(inner_traces);
                 }
+            } else if node_kind == "macro_invocation" {
+                // checks body of unknown fn-like
+                let inner_traces = nested_fn_like(&mut node.walk(), content_bytes, start_line)?;
+
+                if !inner_traces.is_empty() {
+                    traces.extend(inner_traces);
+                }
             } else if node_kind.ends_with("_item")
                 || node_kind == "extern_crate_declaration"
                 || node_kind == "use_declaration"

--- a/langs/mantra-lang-tracing/src/collect/rust/snapshots/mantra_lang_tracing__collect__rust__tests__fn_like_in_unknown_macro.snap
+++ b/langs/mantra-lang-tracing/src/collect/rust/snapshots/mantra_lang_tracing__collect__rust__tests__fn_like_in_unknown_macro.snap
@@ -1,0 +1,41 @@
+---
+source: langs/mantra-lang-tracing/src/collect/rust/tests.rs
+info: "\n        fn foo() {\n            some_other_fn_like!(\n                // some code...\n                satisfy_req!(\"ID2\" => {\n                    // nested code ...\n                });\n            );\n        }\n        "
+---
+Annotations(
+  traces: [
+    Trace(
+      ids: [
+        RequirementPk(
+          id: "ID2",
+          product_id: None,
+        ),
+      ],
+      line: 5,
+      related_code: Some(CodeBlock(
+        kind: other,
+        span: LineSpan(
+          start: 5,
+          end: 7,
+        ),
+        content_hash: Some("f477d0c55e7e23391a21b4182c1d7b8018a740a42f7471567fe32518d6aa0d19"),
+      )),
+      kind: satisfies,
+      properties: None,
+    ),
+  ],
+  elements: [
+    Element(
+      ident: None,
+      name: "foo",
+      definition_line: 2,
+      span: LineSpan(
+        start: 2,
+        end: 9,
+      ),
+      kind: function,
+      content_hash: Some("1eda427728ae85c826acb63121daa87705ccdb13a6b267e5601fd5df4a4673df"),
+    ),
+  ],
+  coverage_excludes: [],
+)

--- a/langs/mantra-lang-tracing/src/collect/rust/snapshots/mantra_lang_tracing__collect__rust__tests__nested_fn_like.snap
+++ b/langs/mantra-lang-tracing/src/collect/rust/snapshots/mantra_lang_tracing__collect__rust__tests__nested_fn_like.snap
@@ -1,0 +1,60 @@
+---
+source: langs/mantra-lang-tracing/src/collect/rust/tests.rs
+info: "\n        fn foo() {\n            satisfy_req!(\"ID1\" => {\n                // some code...\n                clarify_req!(\"ID2\" => {\n                    // nested code ...\n                });\n            });\n        }\n        "
+---
+Annotations(
+  traces: [
+    Trace(
+      ids: [
+        RequirementPk(
+          id: "ID1",
+          product_id: None,
+        ),
+      ],
+      line: 3,
+      related_code: Some(CodeBlock(
+        kind: other,
+        span: LineSpan(
+          start: 3,
+          end: 8,
+        ),
+        content_hash: Some("71f6b19d722ec5d3bb8731ccfe175cf5a8604a53140861f22d16e160acbb0575"),
+      )),
+      kind: satisfies,
+      properties: None,
+    ),
+    Trace(
+      ids: [
+        RequirementPk(
+          id: "ID2",
+          product_id: None,
+        ),
+      ],
+      line: 5,
+      related_code: Some(CodeBlock(
+        kind: other,
+        span: LineSpan(
+          start: 5,
+          end: 7,
+        ),
+        content_hash: Some("c78664e2bc5cb270d988a3bbd224b547df9fbc451672a8feb601d960a47f4665"),
+      )),
+      kind: clarifies,
+      properties: None,
+    ),
+  ],
+  elements: [
+    Element(
+      ident: None,
+      name: "foo",
+      definition_line: 2,
+      span: LineSpan(
+        start: 2,
+        end: 9,
+      ),
+      kind: function,
+      content_hash: Some("0b1cc96b8d46f2515059884f24f60ba6b578ef98d8f0a5f120537b841f145250"),
+    ),
+  ],
+  coverage_excludes: [],
+)

--- a/langs/mantra-lang-tracing/src/collect/rust/tests.rs
+++ b/langs/mantra-lang-tracing/src/collect/rust/tests.rs
@@ -543,3 +543,27 @@ fn attrb_with_literal_id_followed_by_explicit_product_id() {
         }
     );
 }
+
+#[test]
+fn nested_fn_like() {
+    let content = r#"
+        fn foo() {
+            satisfy_req!("ID1" => {
+                // some code...
+                clarify_req!("ID2" => {
+                    // nested code ...
+                });
+            });
+        }
+        "#;
+    let annotations = RustCodeCollector::collect(content).unwrap();
+
+    insta::with_settings!(
+        {
+            info => &content,
+            omit_expression => true
+        }, {
+            insta::assert_ron_snapshot!(annotations);
+        }
+    );
+}

--- a/langs/mantra-lang-tracing/src/collect/rust/tests.rs
+++ b/langs/mantra-lang-tracing/src/collect/rust/tests.rs
@@ -567,3 +567,27 @@ fn nested_fn_like() {
         }
     );
 }
+
+#[test]
+fn fn_like_in_unknown_macro() {
+    let content = r#"
+        fn foo() {
+            some_other_fn_like!(
+                // some code...
+                satisfy_req!("ID2" => {
+                    // nested code ...
+                });
+            );
+        }
+        "#;
+    let annotations = RustCodeCollector::collect(content).unwrap();
+
+    insta::with_settings!(
+        {
+            info => &content,
+            omit_expression => true
+        }, {
+            insta::assert_ron_snapshot!(annotations);
+        }
+    );
+}


### PR DESCRIPTION
Nested fn-like mantra traces are not detected as `macro-invocation`, because tokens inside a fn-like macro may be non-Rust code tokens from the point of the Rust tree-sitter parser.

This fix adds detection based on token order starting with identifier that converts to a valid mantra fn-trace followed by `!`. This is only checked inside the body of a fn-like macro.